### PR TITLE
Setup Allure reporting

### DIFF
--- a/ShoppingApp/app/build.gradle
+++ b/ShoppingApp/app/build.gradle
@@ -16,7 +16,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.kaspersky.kaspresso.runner.KaspressoRunner"
     }
 
     buildFeatures {
@@ -89,7 +89,7 @@ dependencies {
 
     //Kaspresso
     androidTestImplementation 'com.kaspersky.android-components:kaspresso:1.4.0'
-    androidTestImplementation 'com.kaspersky.android-components:kaspresso:1.5.1'
+    androidTestImplementation 'com.kaspersky.android-components:kaspresso-allure-support:1.5.1'
 
     // Lifecycle and Coroutines
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1"

--- a/ShoppingApp/app/src/androidTest/java/com/shopping/app/suites/Regression.kt
+++ b/ShoppingApp/app/src/androidTest/java/com/shopping/app/suites/Regression.kt
@@ -1,0 +1,13 @@
+package com.shopping.app.suites
+
+import com.shopping.app.tests.authentication.SignInTest
+import com.shopping.app.tests.authentication.SignUpTest
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    SignInTest::class,
+    SignUpTest::class
+)
+class Regression

--- a/ShoppingApp/app/src/androidTest/java/com/shopping/app/tests/BaseTest.kt
+++ b/ShoppingApp/app/src/androidTest/java/com/shopping/app/tests/BaseTest.kt
@@ -3,6 +3,8 @@ package com.shopping.app.tests
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.firebase.auth.FirebaseAuth
+import com.kaspersky.components.alluresupport.withForcedAllureSupport
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import com.shopping.app.data.preference.UserPref
 import com.shopping.app.ui.MainActivity
@@ -12,7 +14,7 @@ import kotlinx.coroutines.launch
 import org.junit.After
 import org.junit.Before
 
-open class BaseTest : TestCase() {
+open class BaseTest : TestCase(kaspressoBuilder = Kaspresso.Builder.withForcedAllureSupport()) {
 
     val context = InstrumentationRegistry.getInstrumentation().context
 


### PR DESCRIPTION
The purpose of this change is to setup allure reporting to visualise test results.

Example:

https://github.com/jakubcekala/ShoppingApp/assets/75976627/5e123359-7797-4033-a244-149dfe4dda2e


